### PR TITLE
add "llc" to list of valid host names

### DIFF
--- a/Postman/Postman-Mail/Zend-1.12.10/Validate/Hostname.php
+++ b/Postman/Postman-Mail/Zend-1.12.10/Validate/Hostname.php
@@ -862,6 +862,7 @@ class Postman_Zend_Validate_Hostname extends Postman_Zend_Validate_Abstract
 		'living',
 		'lixil',
 		'lk',
+		'llc',
 		'loan',
 		'loans',
 		'locker',


### PR DESCRIPTION
.llc host names were not sending property, but are valid. See post here: https://wordpress.org/support/topic/error-invalid-to-e-mail-address/

I am not much of a coder, but it seems this is the right place to add this. I haven't tested it just yet, but I will give that a shot.