### PR TITLE
Add filters `wp_mail` and `pre_wp_mail` as in native wp_mail function.

### DIFF
--- a/Postman/PostmanWpMailBinder.php
+++ b/Postman/PostmanWpMailBinder.php
@@ -115,9 +115,33 @@ if (! class_exists ( 'PostmanWpMailBinder' )) {
 				// create an instance of PostmanWpMail to send the message
 				$postmanWpMail = new PostmanWpMail ();
 				// send the mail
-				
-				$mail_data = compact( 'to', 'subject', 'message', 'headers', 'attachments' );
-				
+
+				$mail_data = apply_filters( 'wp_mail', compact( 'to', 'subject', 'message', 'headers', 'attachments' ) );
+
+				/**
+				 * Filters whether to preempt sending an email.
+				 *
+				 * Returning a non-null value will short-circuit {@see wp_mail()}, returning
+				 * that value instead. A boolean return value should be used to indicate whether
+				 * the email was successfully sent.
+				 *
+				 * @param null|bool $return Short-circuit return value.
+				 * @param array     $mail_data {
+				 *     Array of the `wp_mail()` arguments.
+				 *
+				 *     @type string|string[] $to          Array or comma-separated list of email addresses to send message.
+				 *     @type string          $subject     Email subject.
+				 *     @type string          $message     Message contents.
+				 *     @type string|string[] $headers     Additional headers.
+				 *     @type string|string[] $attachments Paths to files to attach.
+				 * }
+				 */
+				$pre_wp_mail = apply_filters( 'pre_wp_mail', null, $mail_data );
+
+				if ( null !== $pre_wp_mail ) {
+					return $pre_wp_mail;
+				}
+
 				$result = $postmanWpMail->send ( $to, $subject, $message, $headers, $attachments );
 				
 				if( $result ) {


### PR DESCRIPTION
Fixes #69. Implements `wp_mail` and `pre_wp_mail` hooks as vanilla WordPress has.