### PR TITLE
Add missing translate function

### DIFF
--- a/Postman/PostmanViewController.php
+++ b/Postman/PostmanViewController.php
@@ -529,15 +529,15 @@ if ( ! class_exists( 'PostmanViewController' ) ) {
 					            printf(
 						            '<p><span>%s</span></p>',
 						            sprintf(
-							            wp_kses_post( 'Let\'s get started! All users are strongly encouraged to <a href="%s">run the Setup Wizard</a>.', 'post-smtp' ),
+							            wp_kses( __( 'Let\'s get started! All users are strongly encouraged to <a href="%s">run the Setup Wizard</a>.', 'post-smtp' ), array( 'a' => array( 'href' => array() ) ) ),
 							            esc_url( $this->getPageUrl( PostmanConfigurationController::CONFIGURATION_WIZARD_SLUG ) )
 						            )
 					            );
 					            printf(
 						            '<p><span>%s</span></p>',
 						            sprintf(
-							            wp_kses_post( 'Alternately, <a href="%s">manually configure</a> your own settings and/or modify advanced options.', 'post-smtp' ),
-							            esc_attr( $this->getPageUrl( PostmanConfigurationController::CONFIGURATION_SLUG ) )
+							            wp_kses( __( 'Alternately, <a href="%s">manually configure</a> your own settings and/or modify advanced options.', 'post-smtp' ), array( 'a' => array( 'href' => array() ) ) ),
+							            esc_url( $this->getPageUrl( PostmanConfigurationController::CONFIGURATION_SLUG ) )
 						            )
 					            );
 				            } else {


### PR DESCRIPTION
This PR:
- Adds a missing translation function.
- Replaces `wp_kses_post` with `wp_kses` and an array of allowed HTML (an `<a>` tag and its `href` attribute) to ensure translators cannot add additional HTML.
- Replaces `esc_attr` with `esc_url` to properly escape the URL, as `esc_url` is the appropriate function for this purpose.

Question:
Does this repository adhere to a specific coding standard? The code contains a mix of tabs and spaces for indentation, sometimes even on the same line. I would have addressed this for the lines affected by this fix, but I could not find any information about the guidelines, if there are any.