### PR TITLE
Remove trailing comma in function calls

### DIFF
--- a/Postman/Dashboard/includes/rest-api/v1/class-psd-rest-api.php
+++ b/Postman/Dashboard/includes/rest-api/v1/class-psd-rest-api.php
@@ -23,9 +23,9 @@ if ( ! class_exists( 'PSD_Rest_API' ) ) {
 				$this->namespace,
 				'/get-logs',
 				array(
-					'methods' => WP_REST_Server::READABLE,
-					'callback' => array( $this, 'get_logs' ),
-					'permission_callback' => array( $this, 'get_logs_permission' )
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_logs' ),
+					'permission_callback' => array( $this, 'get_logs_permission' ),
 				)
 			);
 
@@ -33,9 +33,9 @@ if ( ! class_exists( 'PSD_Rest_API' ) ) {
 				$this->namespace,
 				'/get-details',
 				array(
-					'methods' => WP_REST_Server::READABLE,
-					'callback' => array( $this, 'get_details' ),
-					'permission_callback' => array( $this, 'get_logs_permission' )
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_details' ),
+					'permission_callback' => array( $this, 'get_logs_permission' ),
 				)
 			);
 
@@ -43,9 +43,9 @@ if ( ! class_exists( 'PSD_Rest_API' ) ) {
 				$this->namespace,
 				'/resend-email',
 				array(
-					'methods' => WP_REST_Server::CREATABLE,
-					'callback' => array( $this, 'resend_email' ),
-					'permission_callback' => array( $this, 'get_logs_permission' )
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'resend_email' ),
+					'permission_callback' => array( $this, 'get_logs_permission' ),
 				)
 			);
 
@@ -53,29 +53,29 @@ if ( ! class_exists( 'PSD_Rest_API' ) ) {
 				$this->namespace,
 				'email-count',
 				array(
-					'methods' => WP_REST_Server::READABLE,
-					'callback' => array( $this, 'email_count' ),
-					'permission_callback' => array( $this, 'get_logs_permission' )
-				),
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'email_count' ),
+					'permission_callback' => array( $this, 'get_logs_permission' ),
+				)
 			);
 
 			register_rest_route(
 				$this->namespace,
 				'minimize-maximize-ad',
 				array(
-					'methods' => WP_REST_Server::CREATABLE,
-					'callback' => array( $this, 'minimize_maximize_ad' ),
-					'permission_callback' => array( $this, 'get_logs_permission' )
-				),
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'minimize_maximize_ad' ),
+					'permission_callback' => array( $this, 'get_logs_permission' ),
+				)
 			);
 
 			register_rest_route(
 				$this->namespace,
 				'get-failed-logs',
 				array(
-					'methods' => WP_REST_Server::READABLE,
-					'callback' => array( $this, 'get_failed_logs' ),
-					'permission_callback' => array( $this, 'get_logs_permission' )
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_failed_logs' ),
+					'permission_callback' => array( $this, 'get_logs_permission' ),
 				)
 			);
 
@@ -83,9 +83,9 @@ if ( ! class_exists( 'PSD_Rest_API' ) ) {
 				$this->namespace,
 				'/open-notification',
 				array(
-					'methods' => WP_REST_Server::CREATABLE,
-					'callback' => array( $this, 'open_notification' ),
-					'permission_callback' => array( $this, 'get_logs_permission' )
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'open_notification' ),
+					'permission_callback' => array( $this, 'get_logs_permission' ),
 				)
 			);
 
@@ -93,9 +93,9 @@ if ( ! class_exists( 'PSD_Rest_API' ) ) {
 				$this->namespace,
 				'/remove-notification',
 				array(
-					'methods' => WP_REST_Server::CREATABLE,
-					'callback' => array( $this, 'remove_notification' ),
-					'permission_callback' => array( $this, 'get_logs_permission' )
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'remove_notification' ),
+					'permission_callback' => array( $this, 'get_logs_permission' ),
 				)
 			);
 		}
@@ -104,10 +104,11 @@ if ( ! class_exists( 'PSD_Rest_API' ) ) {
 		 * Get logs
 		 *
 		 * @param WP_REST_Request $request
+		 * @return array<string, bool|int|string|array>
 		 */
-		public function get_logs( $request ) {
+		public function get_logs( $request ): array {
 
-			$logs_query = new PostmanEmailQueryLog;
+			$logs_query = new PostmanEmailQueryLog();
 
 			$data = $logs_query->get_logs(
 				array(
@@ -117,7 +118,7 @@ if ( ! class_exists( 'PSD_Rest_API' ) ) {
 			);
 			$data = array_slice( $data, 0, 4 );
 			$data = array_map(
-				function( $log ) {
+				function ( $log ) {
 					$data = array(
 						'id'            => $log->id,
 						'subject'       => $log->original_subject,
@@ -147,8 +148,9 @@ if ( ! class_exists( 'PSD_Rest_API' ) ) {
 		 * Get details
 		 *
 		 * @param WP_REST_Request $request
+		 * @return array<string, bool|int|string|array>
 		 */
-		public function get_details( $request ) {
+		public function get_details( $request ): array {
 			$id              = $request->get_param( 'id' );
 			$type            = $request->get_param( 'type' );
 			$email_query_log = new PostmanEmailQueryLog();
@@ -170,14 +172,12 @@ if ( ! class_exists( 'PSD_Rest_API' ) ) {
 					}
 				}
 
-				if( isset( $response['time'] ) ) {
-
-					//WordPress Date, Time Format
+				if ( isset( $response['time'] ) ) {
+					// WordPress Date, Time Format
 					$date_format = get_option( 'date_format' );
 					$time_format = get_option( 'time_format' );
 
-					$response['time'] = date( "{$date_format} {$time_format}", $response['time'] );
-
+					$response['time'] = gmdate( "{$date_format} {$time_format}", $response['time'] );
 				}
 
 				if ( $response ) {
@@ -205,8 +205,9 @@ if ( ! class_exists( 'PSD_Rest_API' ) ) {
 		 * Resend email
 		 *
 		 * @param WP_REST_Request $request
+		 * @return array<string, mixed>
 		 */
-		public function resend_email( $request ) {
+		public function resend_email( $request ): array {
 			$id              = $request->get_param( 'id' );
 			$recipient_email = $request->get_param( 'sent_to' );
 
@@ -219,7 +220,7 @@ if ( ! class_exists( 'PSD_Rest_API' ) ) {
 				if ( ! empty( $recipient_email ) ) {
 					$emails = explode( ',', $recipient_email );
 					$to     = array_map(
-						function( $email ) {
+						function ( $email ) {
 							return sanitize_text_field( wp_unslash( $email ) );
 						},
 						$emails
@@ -239,34 +240,37 @@ if ( ! class_exists( 'PSD_Rest_API' ) ) {
 
 				if ( $success ) {
 					$logger->debug( 'Email was successfully re-sent' );
-					$statusMessage = sprintf( __( 'Your message was delivered (%d ms) to the SMTP server! Congratulations :)', 'post-smtp' ), $result ['time'] );
+					$status_message = sprintf(
+						/* Translators: %d: time in milliseconds. */
+						__( 'Your message was delivered (%d ms) to the SMTP server! Congratulations :)', 'post-smtp' ),
+						$result['time']
+					);
 
 					$response = array(
-						'success'       => true,
-						'message'       => $statusMessage,
-						'transcript'    => $transcript,
+						'success'    => true,
+						'message'    => $status_message,
+						'transcript' => $transcript,
 					);
 
 					$logger->trace( 'RestAPI response' );
 					$logger->trace( $response );
 				} else {
-					$logger->error( 'Email was not successfully re-sent - ' . $result ['exception']->getCode() );
+					$logger->error( 'Email was not successfully re-sent - ' . $result['exception']->getCode() );
 					// the message was NOT sent successfully, generate an appropriate message for the user
-					$statusMessage = $result ['exception']->getMessage();
+					$status_message = $result['exception']->getMessage();
 
 					// compose the JSON response for the caller
 					$response = array(
-						'message' => $statusMessage,
+						'message'    => $status_message,
 						'transcript' => $transcript,
 					);
 					$logger->trace( 'RestAPI response' );
 					$logger->trace( $response );
 				}
-
 			} else {
 				$response = array(
 					'success' => false,
-					'message' => __( 'Error Resending Email', 'post-smtp' )
+					'message' => __( 'Error Resending Email', 'post-smtp' ),
 				);
 			}
 
@@ -277,10 +281,11 @@ if ( ! class_exists( 'PSD_Rest_API' ) ) {
 		 * Email count
 		 *
 		 * @param WP_REST_Request $request
+		 * @return array<string, bool|int|string|array<string, int>>
 		 */
-		public function email_count( $request ) {
+		public function email_count( $request ): array {
 			$period        = $request->get_param( 'period' );
-            $opened_emails = $request->get_param( 'opened' );
+			$opened_emails = $request->get_param( 'opened' );
 			$current_time  = current_time( 'timestamp' );
 
 			switch ( $period ) {
@@ -297,62 +302,67 @@ if ( ! class_exists( 'PSD_Rest_API' ) ) {
 					$filter = strtotime( '-1 month', $today );
 					break;
 			}
-            $logs_query = new PostmanEmailQueryLog;
-            $logs = $logs_query->get_logs(
-                array(
-                    'order' => 'desc',
-                    'order_by' => 'id',
-                    'to' => $current_time,
-                    'from' => $filter,
-                )
-            );
+			$logs_query = new PostmanEmailQueryLog();
+			$logs       = $logs_query->get_logs(
+				array(
+					'order'    => 'desc',
+					'order_by' => 'id',
+					'to'       => $current_time,
+					'from'     => $filter,
+				)
+			);
 
-            $success = $logs;
-            $success = array_filter($success, function ($log) {
-                return 1 === absint($log->success);
-            });
+			$success = $logs;
+			$success = array_filter(
+				$success,
+				function ( $log ) {
+					return 1 === absint( $log->success );
+				}
+			);
 
-            $failed = $logs;
-            $failed = array_filter($failed, function ($log) {
-                return 1 !== absint($log->success);
-            });
+			$failed = $logs;
+			$failed = array_filter(
+				$failed,
+				function ( $log ) {
+					return 1 !== absint( $log->success );
+				}
+			);
 
+			$data = array(
+				'success' => true,
+				'message' => 'Email count fetched successfully',
+				'status'  => 200,
+				'count'   => array(
+					'success' => count( $success ),
+					'failed'  => count( $failed ),
+					'total'   => count( $logs ),
+				),
+			);
 
-            $data = array(
-                'success' => true,
-                'message' => 'Email count fetched successfully',
-                'status'  => 200,
-                'count'   => array(
-                    'success' => count( $success ),
-                    'failed'  => count( $failed ),
-                    'total'   => count( $logs ),
-                ),
-            );
+			$opened_emails_count = apply_filters(
+				'post_smtp_dashboard_opened_emails_count',
+				0,
+				array(
+					'period'       => $period,
+					'current_time' => $current_time,
+					'filter'       => $filter,
+				)
+			);
 
-            $opened_emails_count = apply_filters(
-                'post_smtp_dashboard_opened_emails_count',
-                0,
-                array(
-                    'period'       => $period,
-                    'current_time' => $current_time,
-                    'filter'       => $filter,
-                )
-            );
+			if ( $opened_emails_count ) {
+				$data['count']['opened'] = $opened_emails_count;
+			}
 
-
-            if ( $opened_emails_count ) {
-                $data['count']['opened'] = $opened_emails_count;
-            }
-
-            return $data;
+			return $data;
 		}
 
 		/**
 		 * Minimize or maximize ad
 		 *
 		 * @param WP_REST_Request $request
+		 * @return array<string, bool|int|string>
 		 */
-		public function minimize_maximize_ad( $request ) {
+		public function minimize_maximize_ad( $request ): array {
 			$minimize_maximize = $request->get_param( 'minimize_maximize' );
 
 			update_option(
@@ -371,11 +381,10 @@ if ( ! class_exists( 'PSD_Rest_API' ) ) {
 		 * Get failed logs
 		 *
 		 * @param WP_REST_Request $request
-		 *
-		 * @return array
+		 * @return array<string, bool|int|string|array>
 		 */
-		public function get_failed_logs( $request ) {
-			$logs_query = new PostmanEmailQueryLog;
+		public function get_failed_logs( $request ): array {
+			$logs_query = new PostmanEmailQueryLog();
 			$data       = $logs_query->get_logs(
 				array(
 					'order'    => 'desc',
@@ -384,12 +393,12 @@ if ( ! class_exists( 'PSD_Rest_API' ) ) {
 			);
 
 			$current_time = current_time( 'timestamp' );
-			$data = array_map(
-				function( $log ) use ( $current_time ) {
+			$data         = array_map(
+				function ( $log ) use ( $current_time ) {
 					// calculate time difference and convert it into h m or s
 					$time_diff = $current_time - $log->time;
 					$time_diff = human_time_diff( $log->time, $current_time );
-					
+
 					$data = array(
 						'id'            => $log->id,
 						'subject'       => $log->original_subject,
@@ -407,9 +416,9 @@ if ( ! class_exists( 'PSD_Rest_API' ) ) {
 				},
 				$data
 			);
-			$data = array_filter(
+			$data         = array_filter(
 				$data,
-				function( $log ) {
+				function ( $log ) {
 					if ( 'failed' === $log['status'] ) {
 						$deleted_notification = postman_get_log_meta( $log['id'], 'notification_deleted' );
 						if ( ! $deleted_notification ) {
@@ -430,15 +439,15 @@ if ( ! class_exists( 'PSD_Rest_API' ) ) {
 				'status'  => 200,
 				'logs'    => $data,
 			);
-
 		}
 
 		/**
 		 * Open notification
 		 *
 		 * @param WP_REST_Request $request
+		 * @return array<string, bool|int|string>
 		 */
-		public function open_notification( $request ) {
+		public function open_notification( $request ): array {
 			$notification_id = $request->get_param( 'id' );
 
 			postman_update_log_meta(
@@ -458,10 +467,9 @@ if ( ! class_exists( 'PSD_Rest_API' ) ) {
 		 * Remove notification
 		 *
 		 * @param WP_REST_Request $request
-		 *
-		 * @return array
+		 * @return array<string, bool|int|string>
 		 */
-		public function remove_notification( $request ) {
+		public function remove_notification( $request ): array {
 			$notification_id = $request->get_param( 'id' );
 
 			postman_update_log_meta(
@@ -475,7 +483,6 @@ if ( ! class_exists( 'PSD_Rest_API' ) ) {
 				'message' => 'Notification removed successfully',
 				'status'  => 200,
 			);
-
 		}
 
 		/**
@@ -483,7 +490,7 @@ if ( ! class_exists( 'PSD_Rest_API' ) ) {
 		 *
 		 * @return bool
 		 */
-		public function get_logs_permission() {
+		public function get_logs_permission(): bool {
 			return is_user_logged_in();
 		}
 	}


### PR DESCRIPTION
Trailing comma's are not allowed in function calls in PHP 7.2 or earlier. This plugin supports PHP 7.0. Trailing commas are removed on line 59 and 69.

This PR also applies WP coding standards and adds type hints.