### PR TITLE
Update postman-smtp.php

### DIFF
--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Deprecated functions
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+if ( ! function_exists( 'ps_fs' ) ) {
+	/**
+	 * @deprecated 3.0.0 Use post_smtp_fs instead.
+	 */
+	function ps_fs() {
+		_deprecated_function( __FUNCTION__, '3.0.0', 'post_smtp_fs' );
+		return post_smtp_fs();
+	}
+}
+
+/**
+ * @deprecated 3.0.0 Use post_smtp_setup_postman instead.
+ */
+function post_setupPostman() {
+	_deprecated_function( __FUNCTION__, '3.0.0', 'post_smtp_setup_postman' );
+	post_smtp_setup_postman();
+}
+
+/**
+ * @deprecated 3.0.0 Use post_smtp_dismiss_not_configured instead.
+ */
+function post_dismiss_not_configured() {
+	_deprecated_function( __FUNCTION__, '3.0.0', 'post_smtp_dismiss_not_configured' );
+	post_smtp_dismiss_not_configured();
+}
+
+/**
+ * @deprecated 3.0.0 Use post_smtp_fs_custom_icon instead.
+ */
+function ps_fs_custom_icon(): string {
+	_deprecated_function( __FUNCTION__, '3.0.0', 'post_smtp_fs_custom_icon' );
+	return post_smtp_fs_custom_icon();
+}
+
+/**
+ * @deprecated 3.0.0 Use post_smtp_fs_custom_connect_message_on_update instead.
+ */
+function ps_fs_custom_connect_message_on_update(
+	$message,
+	$user_first_name,
+	$product_title,
+	$user_login,
+	$site_link,
+	$freemius_link
+): string {
+	_deprecated_function( __FUNCTION__, '3.0.0', 'post_smtp_fs_custom_connect_message_on_update' );
+	return post_smtp_fs_custom_connect_message_on_update();
+}

--- a/postman-smtp.php
+++ b/postman-smtp.php
@@ -1,18 +1,28 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-    exit; // Exit if accessed directly
-}
-/*
- * Plugin Name: Post SMTP
- * Plugin URI: https://wordpress.org/plugins/post-smtp/
- * Description: Email not reliable? Post SMTP is the first and only WordPress SMTP plugin to implement OAuth 2.0 for Gmail, Hotmail and Yahoo Mail. Setup is a breeze with the Configuration Wizard and integrated Port Tester. Enjoy worry-free delivery even if your password changes!
- * Version: 3.0.0-beta.1
- * Author: Post SMTP
- * Text Domain: post-smtp
- * Author URI: https://postmansmtp.com
- * License: GPLv2 or later
- * License URI: http://www.gnu.org/licenses/gpl-2.0.html
+/**
+ * Post SMTP
+ *
+ * @package           PostSMTP
+ * @author            Post SMTP
+ * @license           GPL-2.0-or-later
+ *
+ * @wordpress-plugin
+ * Plugin Name:       Post SMTP
+ * Plugin URI:        https://wordpress.org/plugins/post-smtp/
+ * Description:       Email not reliable? Post SMTP is the first and only WordPress SMTP plugin to implement OAuth 2.0 for Gmail, Hotmail and Yahoo Mail. Setup is a breeze with the Configuration Wizard and integrated Port Tester. Enjoy worry-free delivery even if your password changes!
+ * Version:           3.0.0-beta.1
+ * Requires at least: 5.6
+ * Requires PHP:      7.0
+ * Author:            Post SMTP
+ * Author URI:        https://postmansmtp.com
+ * Text Domain:       post-smtp
+ * License:           GPLv2 or later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
 
 /*
  * Post SMTP (aka Postman SMTP) was originally developed by Jason Hendriks
@@ -27,132 +37,162 @@ if ( ! defined( 'ABSPATH' ) ) {
 // filter postman_module: implement this filter and return the instance of the module
 // filter postman_register_modules: apply this filter to register the module
 
-/** 
- * Freemius initialization
- * 
- * @since 2.1.1
- * @version 1.0
- */
-if ( ! function_exists( 'ps_fs' ) ) {
-    // Create a helper function for easy SDK access.
-    function ps_fs() {
-        global $ps_fs;
+if ( ! function_exists( 'post_smtp_fs' ) ) {
+	/**
+	 * Initializes and returns the Freemius instance, storing it in the global `$ps_fs`.
+	 *
+	 * @since 2.1.1
+	 * @version 1.0
+	 *
+	 * @return \Freemius The initialized Freemius instance.
+	 * @throws \Freemius_Exception If there is an error during Freemius initialization.
+	 */
+	function post_smtp_fs(): Freemius {
+		global $ps_fs;
 
-        if ( ! isset( $ps_fs ) ) {
-            // Include Freemius SDK.
-            require_once dirname(__FILE__) . '/freemius/start.php';
+		if ( isset( $ps_fs ) ) {
+			return $ps_fs;
+		}
 
-            $ps_fs = fs_dynamic_init( array(
-                'id'                  => '10461',
-                'slug'                => 'post-smtp',
-                'type'                => 'plugin',
-                'public_key'          => 'pk_28fcefa3d0ae86f8cdf6b7f71c0cc',
-                'is_premium'          => false,
-                'has_addons'          => false,
-				'bundle_id' 		  => '10910',
-				'bundle_public_key'   => 'pk_c5110ef04ba30cd57dd970a269a1a',
-                'has_paid_plans'      => false,
-                'menu'                => array(
-                    'slug'           => 'postman',
-                    'first-path'     => 'admin.php?page=postman/configuration_wizard',
-                    'account'        => false,
-                ),
-            ) );
-        }
+		// Include Freemius SDK.
+		require_once __DIR__ . '/freemius/start.php';
 
-        return $ps_fs;
-    }
+		$ps_fs = fs_dynamic_init(
+			array(
+				'id'                => '10461',
+				'slug'              => 'post-smtp',
+				'type'              => 'plugin',
+				'public_key'        => 'pk_28fcefa3d0ae86f8cdf6b7f71c0cc',
+				'is_premium'        => false,
+				'has_addons'        => false,
+				'bundle_id'         => '10910',
+				'bundle_public_key' => 'pk_c5110ef04ba30cd57dd970a269a1a',
+				'has_paid_plans'    => false,
+				'menu'              => array(
+					'slug'       => 'postman',
+					'first-path' => 'admin.php?page=postman/configuration_wizard',
+					'account'    => false,
+				),
+			)
+		);
 
-    // Init Freemius.
-    ps_fs();
-    // Signal that SDK was initiated.
-    do_action( 'ps_fs_loaded' );
+		return $ps_fs;
+	}
+
+	// Init Freemius.
+	post_smtp_fs();
+
+	// Signal that SDK was initiated.
+	do_action_deprecated( 'ps_fs_loaded', array(), '3.0.0', 'post_smtp_fs_loaded' );
+	do_action( 'post_smtp_fs_loaded' );
 }
-
-function ps_fs_custom_connect_message_on_update(
-    $message,
-    $user_first_name,
-    $product_title,
-    $user_login,
-    $site_link,
-    $freemius_link
-) {
-    return sprintf(
-		'<div class="ps-optin-popup">' .
-        '<h1>' . __( 'Stay on the safe side', 'post-smtp' ) . '</h1>' .
-		'<p>'.__( 'Receive our plugin\'s alert in case of critical security and feature updates and allow non-sensitive diagnostic tracking.', 'post-smtp' ).'</p>' .
-		'</div>' . 
-		'<div style="clear: both;"></div>'
-    );
-}
- 
-ps_fs()->add_filter('connect_message', 'ps_fs_custom_connect_message_on_update', 10, 6);
-
-function ps_fs_custom_icon() {
-    return dirname( __FILE__ ) . '/assets/images/icons/optin.png';
-}
- 
-ps_fs()->add_filter( 'plugin_icon' , 'ps_fs_custom_icon' );
-
 
 /**
+ * Retrieves the 'Stay on the safe side' message.
+ *
+ * @since 3.0.0
+ *
+ * @return string Escaped message.
+ */
+function post_smtp_fs_custom_connect_message_on_update(): string {
+	return sprintf(
+		'<div class="ps-optin-popup"><h1>%1$s</h1><p>%2$s</p></div><div style="clear: both;"></div>' .
+		esc_html__( 'Stay on the safe side', 'post-smtp' ),
+		esc_html__( 'Receive our plugin\'s alert in case of critical security and feature updates and allow non-sensitive diagnostic tracking.', 'post-smtp' )
+	);
+}
+
+post_smtp_fs()->add_filter( 'connect_message', 'ps_fs_custom_connect_message_on_update', 10, 0 );
+
+/**
+ * Retrieves the opt-in icon.
+ *
+ * @since 3.0.0
+ *
+ * @return string
+ */
+function post_smtp_fs_custom_icon(): string {
+	return __DIR__ . '/assets/images/icons/optin.png';
+}
+
+post_smtp_fs()->add_filter( 'plugin_icon', 'post_smtp_fs_custom_icon' );
+
+/*
  * DO some check and Start Postman
  */
 
 define( 'POST_SMTP_BASE', __FILE__ );
 define( 'POST_SMTP_PATH', __DIR__ );
-define( 'POST_SMTP_URL', plugins_url('', POST_SMTP_BASE ) );
+define( 'POST_SMTP_URL', plugins_url( '', POST_SMTP_BASE ) );
 define( 'POST_SMTP_VER', '3.0.0' );
 define( 'POST_SMTP_DB_VERSION', '1.0.1' );
 define( 'POST_SMTP_ASSETS', plugin_dir_url( __FILE__ ) . 'assets/' );
 
-$postman_smtp_exist = in_array( 'postman-smtp/postman-smtp.php', (array) get_option( 'active_plugins', array() ) );
-$required_php_version = version_compare( PHP_VERSION, '5.6.0', '<' );
+$postman_smtp_exist = in_array(
+	'postman-smtp/postman-smtp.php',
+	(array) get_option( 'active_plugins', array() ),
+	true
+);
 
-if ( $postman_smtp_exist || $required_php_version ) {
+$post_smtp_required_php_version = version_compare( PHP_VERSION, '7.0', '<' );
+
+if ( $postman_smtp_exist || $post_smtp_required_php_version ) {
 	add_action( 'admin_init', 'post_smtp_plugin_deactivate' );
 
 	if ( $postman_smtp_exist ) {
 		add_action( 'admin_notices', 'post_smtp_plugin_admin_notice' );
 	}
 
-	if ( $required_php_version ) {
+	if ( $post_smtp_required_php_version ) {
 		add_action( 'admin_notices', 'post_smtp_plugin_admin_notice_version' );
 	}
 } else {
 	post_smtp_start( memory_get_usage() );
 }
 
-
+/**
+ * Deactivates the Post SMTP plugin.
+ */
 function post_smtp_plugin_deactivate() {
-		deactivate_plugins( plugin_basename( __FILE__ ) );
-}
-
-function post_smtp_plugin_admin_notice_version() {
-	echo '<div class="error">
-				<p>
-				<strong>Post SMTP</strong> plugin require at least PHP version 5.6, contact to your web hostig support to upgrade.
-				</p>
-				<p>
-				<a href="https://secure.php.net/supported-versions.php">See supported versions on PHP.net</a>
-				</p>
-				</div>';
-
-	if ( isset( $_GET['activate'] ) ) {
-		unset( $_GET['activate'] ); }
-}
-
-function post_smtp_plugin_admin_notice() {
-		echo '<div class="error"><p><strong>Post SMTP</strong> plugin is a fork (twin brother) of the original Postman SMTP, you must disable Postman SMTP to use this plugin.</p></div>';
-
-	if ( isset( $_GET['activate'] ) ) {
-		unset( $_GET['activate'] ); }
+	deactivate_plugins( plugin_basename( __FILE__ ) );
 }
 
 /**
- * @todo
+ * Displays an admin notice about the required PHP version.
  */
-function post_dismiss_not_configured() {
+function post_smtp_plugin_admin_notice_version() {
+	echo '
+		<div class="error">
+			<p><strong>Post SMTP</strong> plugin require at least PHP version 7.0, contact to your web hostig support to upgrade.</p>
+			<p><a href="https://secure.php.net/supported-versions.php">See supported versions on PHP.net</a></p>
+		</div>';
+
+	if ( isset( $_GET['activate'] ) ) {
+		unset( $_GET['activate'] );
+	}
+}
+
+/**
+ * Displays an admin notice that the original Postman SMTP plugin must be disabled first.
+ */
+function post_smtp_plugin_admin_notice() {
+	echo '
+		<div class="error">
+			<p><strong>Post SMTP</strong> plugin is a fork (clone) of the original Postman SMTP, you must disable Postman SMTP to use this plugin.</p>
+		</div>';
+
+	if ( isset( $_GET['activate'] ) ) {
+		unset( $_GET['activate'] );
+	}
+}
+
+/**
+ * Prints script to dismiss the notice that the plugin is not configured.
+ *
+ * @todo
+ * @since 3.0.0
+ */
+function post_smtp_dismiss_not_configured() {
 	?>
 	<script>
 		(function($) {
@@ -172,34 +212,43 @@ function post_dismiss_not_configured() {
 			});
 		})(jQuery);
 	</script>
-<?php
+	<?php
 }
-add_action( 'admin_footer', 'post_dismiss_not_configured' );
+add_action( 'admin_footer', 'post_smtp_dismiss_not_configured' );
 
+/**
+ * Enqueues scripts used in the admin area.
+ */
 function post_smtp_general_scripts() {
-    $localize = include( POST_SMTP_PATH . '/Postman/Localize.php' );
-    wp_register_script( 'post-smtp-localize', POST_SMTP_URL . '/script/localize.js', [], false );
-    wp_localize_script( 'post-smtp-localize', 'post_smtp_localize', $localize );
-    wp_enqueue_script( 'post-smtp-localize' );
-    wp_enqueue_script( 'post-smtp-hooks', POST_SMTP_URL . '/script/post-smtp-hooks.js', [], false );
+	$localize = include POST_SMTP_PATH . '/Postman/Localize.php';
+	$args     = version_compare( get_bloginfo( 'version' ), '6.3', '<' ) ? true : array( 'in_footer' => true );
+	wp_register_script( 'post-smtp-localize', POST_SMTP_URL . '/script/localize.js', array(), POST_SMTP_VER, $args );
+	wp_localize_script( 'post-smtp-localize', 'post_smtp_localize', $localize );
+	wp_enqueue_script( 'post-smtp-localize' );
+	wp_enqueue_script( 'post-smtp-hooks', POST_SMTP_URL . '/script/post-smtp-hooks.js', array(), POST_SMTP_VER, $args );
 }
 add_action( 'admin_enqueue_scripts', 'post_smtp_general_scripts', 8 );
 
 /**
  * Create the main Postman class to start Postman
  *
- * @param mixed $startingMemory
+ * @param int $starting_memory The amount of memory, in bytes, that's being
+ *                             allocated to the PHP script when initialising Postman.
  */
-function post_smtp_start( $startingMemory ) {
-	post_setupPostman();
-	PostmanUtils::logMemoryUse( $startingMemory, 'Postman' );
+function post_smtp_start( $starting_memory ) {
+	post_smtp_setup_postman();
+	PostmanUtils::logMemoryUse( $starting_memory, 'Postman' );
 }
 
 /**
  * Instantiate the mail Postman class
+ *
+ * @since 3.0.0
  */
-function post_setupPostman() {
+function post_smtp_setup_postman() {
 	require_once 'Postman/Postman.php';
-	$kevinCostner = new Postman( __FILE__, POST_SMTP_VER );
-	do_action( 'post_smtp_init');
+	$postman = new Postman( __FILE__, POST_SMTP_VER );
+	do_action( 'post_smtp_init' );
 }
+
+require_once __DIR__ . 'includes/deprecated.php';


### PR DESCRIPTION
This PR introduces several updates to the `postman-smtp.php` file:

- Adopts the DocBlock plugin header style.
- Adds `Requires at least` and `Requires PHP` headers to ensure compatibility checks are clear and explicit.
- Standardises on `post_smtp` as the unique plugin slug (likely something that could and should be done in other files as well) to ensure `post_smtp` is used consistently and properly deprecates other slug versions.
- Implements version-based cache busting for registered scripts to ensure browsers correctly invalidate cached assets upon updates.
- Prints scripts in the footer.
- Updates the required PHP version in `version_compare()` checks to reflect that the plugin requires PHP 7.0. However, I believe WordPress performs compatibility checks natively, and if so, this check could be removed altogether.
- Adds DocBlocks and type hints to provide clearer documentation.
- Prevents overriding the WordPress global `$requires_php_version` to ensure no conflicts with WordPress' built-in version handling.

Please note that none of these changes has been tested.