### PR TITLE
Fix per-site activation/deactivation logic on multisite

### DIFF
--- a/Postman/PostmanInstaller.php
+++ b/Postman/PostmanInstaller.php
@@ -83,7 +83,7 @@ class PostmanInstaller {
 			}
 		}
 
-		if ( function_exists( 'is_multisite' ) && is_multisite() ) {
+		if ( is_multisite() && is_network_admin() && is_plugin_active_for_network( plugin_basename( __FILE__ ) ) ) {
 			
 			$network_options = get_site_option( PostmanOptions::POSTMAN_NETWORK_OPTIONS );
 
@@ -120,7 +120,7 @@ class PostmanInstaller {
 	 * Handle deactivation of the plugin
 	 */
 	public function deactivatePostman() {
-		if ( function_exists( 'is_multisite' ) && is_multisite() ) {
+		if ( is_multisite() && is_network_admin() && is_plugin_active_for_network( plugin_basename( __FILE__ ) ) ) {
 			// handle network deactivation
 			// from https://wordpress.org/support/topic/new-function-wp_get_sites?replies=11
 			// run the deactivation function for each blog id

--- a/postman-smtp.php
+++ b/postman-smtp.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Plugin Name: Post SMTP
  * Plugin URI: https://wordpress.org/plugins/post-smtp/
  * Description: Email not reliable? Post SMTP is the first and only WordPress SMTP plugin to implement OAuth 2.0 for Gmail, Hotmail and Yahoo Mail. Setup is a breeze with the Configuration Wizard and integrated Port Tester. Enjoy worry-free delivery even if your password changes!
- * Version: 3.2.0
+ * Version: 3.2.1
  * Author: Post SMTP
  * Text Domain: post-smtp
  * Author URI: https://postmansmtp.com


### PR DESCRIPTION
This PR updates the plugin’s activation and deactivation logic to correctly handle per-site activations within a multisite network.

Currently, any activation on a multisite (even if only on a single subsite) would incorrectly run capability setup for all sites. Likewise, deactivating the plugin on one subsite would remove capabilities from every site in the network.

With this update, the activation and deactivations hooks will appropriately fire for network-wide activation vs single-site (but still within a network) activation.